### PR TITLE
Adding a Code of Conduct

### DIFF
--- a/source/code-of-conduct.html.md
+++ b/source/code-of-conduct.html.md
@@ -1,0 +1,136 @@
+# Code of Conduct
+
+## 1. Purpose
+
+A primary goal of VicDev is to be inclusive to the largest number of
+contributors, with the most varied and diverse backgrounds possible. As such, we
+are committed to providing a friendly, safe and welcoming environment for all,
+regardless of gender, sexual orientation, ability, ethnicity, socioeconomic
+status, and religion (or lack thereof).
+
+This code of conduct outlines our expectations for all those who participate in
+our community, as well as the consequences for unacceptable behavior.
+
+We invite all those who participate in VicDev to help us create safe and
+positive experiences for everyone.
+
+## 2. Open Tech Citizenship
+
+A supplemental goal of this Code of Conduct is to increase open tech citizenship
+by encouraging participants to recognize and strengthen the relationships
+between our actions and their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is
+essential to counteract the many forms of inequality and abuses of power that
+exist in society.
+
+If you see someone who is making an extra effort to ensure our community is
+welcoming, friendly, and encourages all participants to contribute to the
+fullest extent, we want to know.
+
+## 3. Expected Behavior
+
+The following behaviors are expected and requested of all community members:
+
+  * Participate in an authentic and active way. In doing so, you contribute to
+    the health and longevity of this community.
+  * Exercise consideration and respect in your speech and actions.
+  * Attempt collaboration before conflict.
+  * Refrain from demeaning, discriminatory, or harassing behavior and speech.
+  * Be mindful of your surroundings and of your fellow participants. Alert
+    community leaders if you notice a dangerous situation, someone in distress,
+or violations of this Code of Conduct, even if they seem inconsequential.
+  * Remember that community event venues may be shared with members of the
+    public; please be respectful to all patrons of these locations.
+
+## 4. Unacceptable Behavior
+
+The following behaviors are considered harassment and are unacceptable within
+our community:
+
+  * Violence, threats of violence or violent language directed against another
+    person.
+  * Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory
+    jokes and language.
+  * Posting or displaying sexually explicit or violent material.
+  * Posting or threatening to post other people's personally identifying
+    information ("doxing").
+  * Personal insults, particularly those related to gender, sexual orientation,
+    race, religion, or disability.
+  * Inappropriate photography or recording.
+  * Inappropriate physical contact. You should have someone's consent before
+    touching them.
+  * Unwelcome sexual attention. This includes, sexualized comments or jokes;
+    inappropriate touching, groping, and unwelcomed sexual advances.
+  * Deliberate intimidation, stalking or following (online or in person).
+  * Advocating for, or encouraging, any of the above behavior.
+  * Sustained disruption of community events, including talks and presentations.
+
+## 5. Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any community member, including sponsors and those
+with decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, the community organizers
+may take any action they deem appropriate, up to and including a temporary ban
+or permanent expulsion from the community without warning (and without refund in
+the case of a paid event).
+
+## 6. Reporting Guidelines
+
+If you are subject to or witness unacceptable behavior, or have any other
+concerns, please notify us as soon as possible by emailing Matthew and Jason
+(the VicDev community leaders) at [info@vicdev.io][vicdev-email]. Please read
+[Reporting Guidelines][reporting-guidelines] for details.
+
+Additionally, community organizers are available to help community members
+engage with local law enforcement or to otherwise help those experiencing
+unacceptable behavior feel safe. In the context of in-person events, organizers
+will also provide escorts as desired by the person experiencing distress.
+
+## 7. Addressing Grievances
+
+Only permanent resolutions (such as bans) may be appealed. To appeal a decision
+of the community leadership, email [info@vicdev.io][vicdev-email] and we will
+review the case.
+
+## 8. Scope
+
+We expect all community participants (contributors, paid or otherwise; sponsors;
+and other guests) to abide by this Code of Conduct in all community
+venues--online and in-person--as well as in all one-on-one communications
+pertaining to community business.
+
+This code of conduct and its related procedures also applies to unacceptable
+behavior occurring outside the scope of community activities when such behavior
+has the potential to adversely affect the safety and well-being of community
+members.
+
+## 9. Contact info
+
+* Jason Trill – [jason@vicdev.io](mailto:jason@vicdev.io)
+* Matthew Lehner – [matthew@vicdev.io](mailto:matthew@vicdev.io)
+
+## 10. License and attribution
+
+The Citizen Code of Conduct is distributed by [Stumptown
+Syndicate](http://stumptownsyndicate.org) under a [Creative Commons
+Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/).
+
+Portions of text derived from the [Django Code of
+Conduct](https://www.djangoproject.com/conduct/) and the [Geek Feminism
+Anti-Harassment
+Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
+
+_Revision 2.2. Posted 4 February 2016._
+
+_Revision 2.1. Posted 23 June 2014._
+
+_Revision 2.0, adopted by the [Stumptown
+Syndicate](http://stumptownsyndicate.org) board on 10 January 2013. Posted 17
+March 2013._
+
+[reporting-guidelines]: /reporting-guidelines
+[vicdev-email]: mailto:info@vicdev.io

--- a/source/reporting-guidelines.html.md
+++ b/source/reporting-guidelines.html.md
@@ -1,0 +1,71 @@
+# Reporting Guidelines
+
+If you believe someone is violating the code of conduct we ask that you report
+it to the VicDev community leaders by emailing info@vicdev.io.
+
+**All reports will be kept confidential.** In some cases we may determine that a
+public statement will need to be made. If that’s the case, the identities of all
+victims and reporters will remain confidential unless those individuals instruct
+us otherwise.
+
+If you believe anyone is in physical danger, please notify appropriate law
+enforcement first. If you are unsure what law enforcement agency is appropriate,
+please include this in your report and we will attempt to notify them.
+
+In your report please include:
+
+* Your contact info (so we can get in touch with you if we need to follow up)
+* Names (real, nicknames, or pseudonyms) of any individuals involved. If there
+  were other witnesses besides you, please try to include them as well.
+* When and where the incident occurred. Please be as specific as possible.
+* Your account of what occurred. If there is a publicly available record (e.g. a
+  mailing list archive or a public IRC logger) please include a link.
+* Any extra context you believe existed for the incident.
+* If you believe this incident is ongoing.
+* Any other information you believe we should have.
+* What happens after you file a report?
+
+You will receive an email from the VicDev community leaders acknowledging
+receipt within 24 hours (and will aim for much quicker than that).
+
+The working group will immediately meet to review the incident and determine:
+
+* What happened.
+* Whether this event constitutes a code of conduct violation.
+* Who the bad actor was.
+* Whether this is an ongoing situation, or if there is a threat to anyone’s
+  physical safety.
+
+If this is determined to be an ongoing incident or a threat to physical safety,
+the working groups’ immediate priority will be to protect everyone involved.
+This means we may delay an "official" response until we believe that the
+situation has ended and that everyone is physically safe.
+
+Once the working group has a complete account of the events they will make a
+decision as to how to respond. Responses may include:
+
+* Nothing (if we determine no violation occurred).
+* A private reprimand from the working group to the individual(s) involved.
+* A public reprimand.
+* An imposed vacation (i.e. asking someone to "take a week off" from a mailing
+  list or IRC).
+* A permanent or temporary ban from some or all VicDev spaces (events, meetings,
+  mailing lists, IRC, etc.)
+* A request for a public or private apology.
+* A request to engage in mediation and/or an accountability plan.
+* We’ll respond within one week to the person who filed the report with either a
+  resolution or an explanation of why the situation is not yet resolved.
+
+Once we’ve determined our final action, we’ll contact the original reporter to
+let them know what action (if any) we’ll be taking. We’ll take into account
+feedback from the reporter on the appropriateness of our response, but we don’t
+guarantee we’ll act on it.
+
+### Appealing
+
+Only permanent resolutions (such as bans) may be appealed. To appeal a decision
+of the working group, contact VicDev at info@vicdev.io with your appeal and we
+will review the case.
+
+Revision 1.0, posted February 4, 2015 Reporting Guidelines derived from those of
+the Django Software Foundation.


### PR DESCRIPTION
Both @jjt and I have been working on a putting together a code of conduct as we want VicDev to be an inclusive environment for all developers and hope this helps lay a solid foundation as we get started. 

We've leaned heavily on [Codes of Conduct 101 FAQ](http://www.ashedryden.com/blog/codes-of-conduct-101-faq) from Ashe Dryden and chose to adopt the [Citizen Code of Conduct](http://citizencodeofconduct.org).

Have a look through our draft [code of conduct](source/code-of-conduct.html.md) and [reporting guidelines](source/reporting-guidelints.html.md).

We'd love any feedback, thoughts, or opinions you've got, just reply here, or submit a PR to the `code-of-conduct` branch. Alternatively, you can email either of us at matthew@vicdev.io or jason@vicdev.io or ping us privately on slack.
